### PR TITLE
Disallow reentrant withdrawals

### DIFF
--- a/contracts/upgradeable_contracts/ForeignOmnibridge.sol
+++ b/contracts/upgradeable_contracts/ForeignOmnibridge.sol
@@ -75,6 +75,10 @@ contract ForeignOmnibridge is BasicOmnibridge, GasLimitManager {
         address _recipient,
         uint256 _value
     ) internal override {
+        // prohibit withdrawal of tokens during other bridge operations (e.g. relayTokens)
+        // such reentrant withdrawal can lead to an incorrect balanceDiff calculation
+        require(!lock());
+
         require(withinExecutionLimit(_token, _value));
         addTotalExecutedPerDay(_token, getCurrentDay(), _value);
 

--- a/contracts/upgradeable_contracts/HomeOmnibridge.sol
+++ b/contracts/upgradeable_contracts/HomeOmnibridge.sol
@@ -119,6 +119,10 @@ contract HomeOmnibridge is
         address _recipient,
         uint256 _value
     ) internal override {
+        // prohibit withdrawal of tokens during other bridge operations (e.g. relayTokens)
+        // such reentrant withdrawal can lead to an incorrect balanceDiff calculation
+        require(!lock());
+
         require(withinExecutionLimit(_token, _value));
         addTotalExecutedPerDay(_token, getCurrentDay(), _value);
 


### PR DESCRIPTION
Some ERC20 compatible tokens with unusual implementation of `transferFrom` function might execute a callback on the sender address. In such callbacks, arbitrary code can be executed. This can lead to different problems with balance accounting.

Assume the following sequence of events:
1) User contract approves Token A to be withdrawn by the Omnibridge contract
2) User contract calls `relayTokens(token, X)` on the Omnibridge contract
3) Omnibridge contract records its prior balance - `balanceBefore`
4) Omnibridge calls `token.transferFrom(user, address(this), X)`
5) Token contract executes a callback on the user contract, arbitrary code containing `amb.executeSignatures()` is executed. AMB message execution leads to withdrawal of some amount of Tokens A - `Y`. `Y < X`
6) Omnibridge contract evaluates new balance - `balanceAfter = balanceBefore + X - Y`
7) Omnibridge contract passes a message via the AMB containing the `X - Y` amount of tokens.
8) New `mediatorBalance(token)` becomes - `balanceBefore - Y + X - Y`, however it should be equal to `balanceBefore - Y + X`
9) User receives only `X - Y` tokens, although they expected to receive `X` tokens.

In the described case, the desired behaviour would be to block execution of the nested AMB message. However, it is not possible to block it, since AMB contracts logic does not depend on the particular mediator implementation. Still, it is possible to revert execution of such message in the mediator code. 

The other source of problems might be the case when user transfers tokens to the Omnibridge instead of withdrawing them  in `5)`. There is not way to regulate such behaviour, since tokens might be transferred without Omnibridge acknowledgement using a regular `transfer()` method. Although it might be a bit confusing that the double transfer inside the `transferFrom` function resulted in the single message passing with combined value, such behaviour is acceptable. 