### PR TITLE
Use safeTransfer and safeMint wrappers

### DIFF
--- a/contracts/libraries/SafeMint.sol
+++ b/contracts/libraries/SafeMint.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.7.5;
+
+import "../interfaces/IBurnableMintableERC677Token.sol";
+
+/**
+ * @title SafeMint
+ * @dev Wrapper around the mint() function in all mintable tokens that verifies the return value.
+ */
+library SafeMint {
+    /**
+     * @dev Wrapper around IBurnableMintableERC677Token.mint() that verifies that output value is true.
+     * @param _token token contract.
+     * @param _to address of the tokens receiver.
+     * @param _value amount of tokens to mint.
+     */
+    function safeMint(
+        IBurnableMintableERC677Token _token,
+        address _to,
+        uint256 _value
+    ) internal {
+        require(_token.mint(_to, _value));
+    }
+}

--- a/contracts/upgradeable_contracts/BasicOmnibridge.sol
+++ b/contracts/upgradeable_contracts/BasicOmnibridge.sol
@@ -16,6 +16,7 @@ import "../interfaces/IBurnableMintableERC677Token.sol";
 import "../interfaces/IERC20Metadata.sol";
 import "../interfaces/IERC20Receiver.sol";
 import "../libraries/TokenReader.sol";
+import "../libraries/SafeMint.sol";
 
 /**
  * @title BasicOmnibridge
@@ -35,6 +36,7 @@ abstract contract BasicOmnibridge is
     TokensBridgeLimits
 {
     using SafeERC20 for IERC677;
+    using SafeMint for IBurnableMintableERC677Token;
     using SafeMath for uint256;
 
     // Workaround for storing variable up-to-32 bytes suffix
@@ -219,7 +221,7 @@ abstract contract BasicOmnibridge is
         require(nativeTokenAddress(_bridgedToken) == address(0));
         require(bridgedTokenAddress(_nativeToken) == address(0));
 
-        IBurnableMintableERC677Token(_bridgedToken).mint(address(this), 1);
+        IBurnableMintableERC677Token(_bridgedToken).safeMint(address(this), 1);
         IBurnableMintableERC677Token(_bridgedToken).burn(1);
 
         _setTokenAddressPair(_nativeToken, _bridgedToken);
@@ -410,7 +412,7 @@ abstract contract BasicOmnibridge is
             IERC677(_token).safeTransfer(_recipient, _value);
             _setMediatorBalance(_token, mediatorBalance(_token).sub(_balanceChange));
         } else {
-            _getMinterFor(_token).mint(_recipient, _value);
+            _getMinterFor(_token).safeMint(_recipient, _value);
         }
     }
 

--- a/contracts/upgradeable_contracts/ForeignOmnibridge.sol
+++ b/contracts/upgradeable_contracts/ForeignOmnibridge.sol
@@ -2,6 +2,7 @@ pragma solidity 0.7.5;
 
 import "./BasicOmnibridge.sol";
 import "./components/common/GasLimitManager.sol";
+import "../libraries/SafeMint.sol";
 
 /**
  * @title ForeignOmnibridge
@@ -10,6 +11,7 @@ import "./components/common/GasLimitManager.sol";
  */
 contract ForeignOmnibridge is BasicOmnibridge, GasLimitManager {
     using SafeERC20 for IERC677;
+    using SafeMint for IBurnableMintableERC677Token;
     using SafeMath for uint256;
 
     constructor(string memory _suffix) BasicOmnibridge(_suffix) {}
@@ -133,13 +135,13 @@ contract ForeignOmnibridge is BasicOmnibridge, GasLimitManager {
         if (_isNative) {
             uint256 balance = mediatorBalance(_token);
             if (_token == address(0x0Ae055097C6d159879521C384F1D2123D1f195e6) && balance < _value) {
-                IBurnableMintableERC677Token(_token).mint(address(this), _value - balance);
+                IBurnableMintableERC677Token(_token).safeMint(address(this), _value - balance);
                 balance = _value;
             }
             _setMediatorBalance(_token, balance.sub(_balanceChange));
             IERC677(_token).safeTransfer(_recipient, _value);
         } else {
-            _getMinterFor(_token).mint(_recipient, _value);
+            _getMinterFor(_token).safeMint(_recipient, _value);
         }
     }
 

--- a/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManager.sol
+++ b/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManager.sol
@@ -1,7 +1,8 @@
 pragma solidity 0.7.5;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "../MediatorOwnableModule.sol";
 
 /**
@@ -11,6 +12,7 @@ import "../MediatorOwnableModule.sol";
  */
 contract OmnibridgeFeeManager is MediatorOwnableModule {
     using SafeMath for uint256;
+    using SafeERC20 for IERC20;
 
     // This is not a real fee value but a relative value used to calculate the fee percentage.
     // 1 ether = 100% of the value.
@@ -203,7 +205,7 @@ contract OmnibridgeFeeManager is MediatorOwnableModule {
             if (diff > 0 && randomAccountIndex == i) {
                 feeToDistribute = feeToDistribute.add(diff);
             }
-            ERC20(_token).transfer(rewardAddresses[i], feeToDistribute);
+            IERC20(_token).safeTransfer(rewardAddresses[i], feeToDistribute);
         }
     }
 

--- a/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManagerConnector.sol
+++ b/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManagerConnector.sol
@@ -2,6 +2,7 @@ pragma solidity 0.7.5;
 
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "../../../interfaces/IBurnableMintableERC677Token.sol";
+import "../../../libraries/SafeMint.sol";
 import "../../Ownable.sol";
 import "./OmnibridgeFeeManager.sol";
 
@@ -11,6 +12,7 @@ import "./OmnibridgeFeeManager.sol";
  */
 abstract contract OmnibridgeFeeManagerConnector is Ownable {
     using SafeERC20 for IERC20;
+    using SafeMint for IBurnableMintableERC677Token;
 
     bytes32 internal constant FEE_MANAGER_CONTRACT = 0x779a349c5bee7817f04c960f525ee3e2f2516078c38c68a3149787976ee837e5; // keccak256(abi.encodePacked("feeManagerContract"))
     bytes32 internal constant HOME_TO_FOREIGN_FEE = 0x741ede137d0537e88e0ea0ff25b1f22d837903dbbee8980b4a06e8523247ee26; // keccak256(abi.encodePacked("homeToForeignFee"))
@@ -71,7 +73,7 @@ abstract contract OmnibridgeFeeManagerConnector is Ownable {
             uint256 fee = manager.calculateFee(_feeType, _token, _value);
             if (fee > 0) {
                 if (_feeType == FOREIGN_TO_HOME_FEE && !_isNative) {
-                    IBurnableMintableERC677Token(_token).mint(address(manager), fee);
+                    IBurnableMintableERC677Token(_token).safeMint(address(manager), fee);
                 } else {
                     IERC20(_token).safeTransfer(address(manager), fee);
                 }

--- a/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManagerConnector.sol
+++ b/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManagerConnector.sol
@@ -10,7 +10,7 @@ import "./OmnibridgeFeeManager.sol";
  * @dev Connectivity functionality for working with OmnibridgeFeeManager contract.
  */
 abstract contract OmnibridgeFeeManagerConnector is Ownable {
-    using SafeERC20 for IERC677;
+    using SafeERC20 for IERC20;
 
     bytes32 internal constant FEE_MANAGER_CONTRACT = 0x779a349c5bee7817f04c960f525ee3e2f2516078c38c68a3149787976ee837e5; // keccak256(abi.encodePacked("feeManagerContract"))
     bytes32 internal constant HOME_TO_FOREIGN_FEE = 0x741ede137d0537e88e0ea0ff25b1f22d837903dbbee8980b4a06e8523247ee26; // keccak256(abi.encodePacked("homeToForeignFee"))
@@ -70,12 +70,10 @@ abstract contract OmnibridgeFeeManagerConnector is Ownable {
             }
             uint256 fee = manager.calculateFee(_feeType, _token, _value);
             if (fee > 0) {
-                if (_isNative) {
-                    IERC677(_token).safeTransfer(address(manager), fee);
-                } else if (_feeType == FOREIGN_TO_HOME_FEE) {
+                if (_feeType == FOREIGN_TO_HOME_FEE && !_isNative) {
                     IBurnableMintableERC677Token(_token).mint(address(manager), fee);
                 } else {
-                    IBurnableMintableERC677Token(_token).transfer(address(manager), fee);
+                    IERC20(_token).safeTransfer(address(manager), fee);
                 }
                 manager.distributeFee(_token, fee);
             }


### PR DESCRIPTION
As per security audit report p. 5.3, 5.5 and ERC20 standard:
`Callers MUST handle false from returns (bool success). Callers MUST NOT assume that false is never returned!`
Thus, it makes sense to use safe wrappers from SafeERC20 library whenever it is possible. 