### PR TITLE
Refactor readDecimals calls

### DIFF
--- a/contracts/libraries/TokenReader.sol
+++ b/contracts/libraries/TokenReader.sol
@@ -58,7 +58,7 @@ library TokenReader {
      * @param _token address of the token contract.
      * @return token decimals or 0 if none of the methods succeeded.
      */
-    function readDecimals(address _token) internal view returns (uint256) {
+    function readDecimals(address _token) internal view returns (uint8) {
         (bool status, bytes memory data) = _token.staticcall(abi.encodeWithSelector(ITokenDetails.decimals.selector));
         if (!status) {
             (status, data) = _token.staticcall(abi.encodeWithSelector(ITokenDetails.DECIMALS.selector));
@@ -66,7 +66,7 @@ library TokenReader {
                 return 0;
             }
         }
-        return abi.decode(data, (uint256));
+        return abi.decode(data, (uint8));
     }
 
     /**

--- a/contracts/upgradeable_contracts/BasicOmnibridge.sol
+++ b/contracts/upgradeable_contracts/BasicOmnibridge.sol
@@ -249,8 +249,7 @@ abstract contract BasicOmnibridge is
         }
         addTotalSpentPerDay(_token, getCurrentDay(), diff);
 
-        uint8 decimals = uint8(TokenReader.readDecimals(_token));
-        bytes memory data = _prepareMessage(address(0), _token, _receiver, diff, decimals, new bytes(0));
+        bytes memory data = _prepareMessage(address(0), _token, _receiver, diff, new bytes(0));
         bytes32 _messageId = _passMessage(data, true);
         _recordBridgeOperation(_messageId, _token, _receiver, diff);
     }
@@ -309,7 +308,6 @@ abstract contract BasicOmnibridge is
      * @param _token bridged token address.
      * @param _receiver address of the tokens receiver on the other side.
      * @param _value bridged value.
-     * @param _decimals token decimals parameter.
      * @param _data additional transfer data passed from the other side.
      */
     function _prepareMessage(
@@ -317,7 +315,6 @@ abstract contract BasicOmnibridge is
         address _token,
         address _receiver,
         uint256 _value,
-        uint8 _decimals,
         bytes memory _data
     ) internal returns (bytes memory) {
         bool withData = _data.length > 0 || msg.sig == this.relayTokensAndCall.selector;
@@ -340,6 +337,7 @@ abstract contract BasicOmnibridge is
                         : abi.encodeWithSelector(this.handleBridgedTokens.selector, _token, _receiver, _value);
             }
 
+            uint8 decimals = TokenReader.readDecimals(_token);
             string memory name = TokenReader.readName(_token);
             string memory symbol = TokenReader.readSymbol(_token);
 
@@ -352,7 +350,7 @@ abstract contract BasicOmnibridge is
                         _token,
                         name,
                         symbol,
-                        _decimals,
+                        decimals,
                         _receiver,
                         _value,
                         _data
@@ -362,7 +360,7 @@ abstract contract BasicOmnibridge is
                         _token,
                         name,
                         symbol,
-                        _decimals,
+                        decimals,
                         _receiver,
                         _value
                     );

--- a/contracts/upgradeable_contracts/ForeignOmnibridge.sol
+++ b/contracts/upgradeable_contracts/ForeignOmnibridge.sol
@@ -100,17 +100,16 @@ contract ForeignOmnibridge is BasicOmnibridge, GasLimitManager {
     ) internal virtual override {
         require(_receiver != address(0) && _receiver != mediatorContractOnOtherSide());
 
-        uint8 decimals = uint8(TokenReader.readDecimals(_token));
-
         // native unbridged token
         if (!isTokenRegistered(_token)) {
+            uint8 decimals = TokenReader.readDecimals(_token);
             _initializeTokenBridgeLimits(_token, decimals);
         }
 
         require(withinLimit(_token, _value));
         addTotalSpentPerDay(_token, getCurrentDay(), _value);
 
-        bytes memory data = _prepareMessage(nativeTokenAddress(_token), _token, _receiver, _value, decimals, _data);
+        bytes memory data = _prepareMessage(nativeTokenAddress(_token), _token, _receiver, _value, _data);
         bytes32 _messageId = _passMessage(data, true);
         _recordBridgeOperation(_messageId, _token, _from, _value);
     }

--- a/contracts/upgradeable_contracts/HomeOmnibridge.sol
+++ b/contracts/upgradeable_contracts/HomeOmnibridge.sol
@@ -152,21 +152,20 @@ contract HomeOmnibridge is
     ) internal override {
         require(_receiver != address(0) && _receiver != mediatorContractOnOtherSide());
 
-        uint8 decimals = uint8(TokenReader.readDecimals(_token));
-        address nativeToken = nativeTokenAddress(_token);
-
         // native unbridged token
         if (!isTokenRegistered(_token)) {
+            uint8 decimals = TokenReader.readDecimals(_token);
             _initializeTokenBridgeLimits(_token, decimals);
         }
 
         require(withinLimit(_token, _value));
         addTotalSpentPerDay(_token, getCurrentDay(), _value);
 
+        address nativeToken = nativeTokenAddress(_token);
         uint256 fee = _distributeFee(HOME_TO_FOREIGN_FEE, nativeToken == address(0), _from, _token, _value);
         uint256 valueToBridge = _value.sub(fee);
 
-        bytes memory data = _prepareMessage(nativeToken, _token, _receiver, valueToBridge, decimals, _data);
+        bytes memory data = _prepareMessage(nativeToken, _token, _receiver, valueToBridge, _data);
 
         // Address of the home token is used here for determining lane permissions.
         bytes32 _messageId = _passMessage(data, _isOracleDrivenLaneAllowed(_token, _from, _receiver));


### PR DESCRIPTION
Previously, each bridge operation included a call to `token.decimals()`, which can be skipped in most of the cases. So I have decided to refactor this logic a little bit and reduce gas usage. Now it is being called only when `deployAndHandleTokens*` messages are sent. 

I tried to keep the logic simple, so, unfortunately the decimals will be read twice on the very first bridging of native tokens (in `bridgeSpecificOperationOnTokenTransfer` and in  `_prepareMessage``). But I guess simplicity of code is worth it.