### PR TITLE
Comment about required manual checks to setCustomTokenAddressPair

### DIFF
--- a/contracts/upgradeable_contracts/BasicOmnibridge.sol
+++ b/contracts/upgradeable_contracts/BasicOmnibridge.sol
@@ -218,6 +218,11 @@ abstract contract BasicOmnibridge is
         require(!isTokenRegistered(_bridgedToken));
         require(nativeTokenAddress(_bridgedToken) == address(0));
         require(bridgedTokenAddress(_nativeToken) == address(0));
+        // Unfortunately, there is no simple way to verify that the _nativeToken address
+        // does not belong to the bridged token on the other side,
+        // since information about bridged tokens addresses is not transferred back.
+        // Therefore, owner account calling this function SHOULD manually verify on the other side of the bridge that
+        // nativeTokenAddress(_nativeToken) == address(0) && isTokenRegistered(_nativeToken) == false.
 
         IBurnableMintableERC677Token(_bridgedToken).mint(address(this), 1);
         IBurnableMintableERC677Token(_bridgedToken).burn(1);


### PR DESCRIPTION
When the function `setCustomTokenAddressPair` is called, the following checks are being performed:
```solidity
require(!isTokenRegistered(_bridgedToken));
require(nativeTokenAddress(_bridgedToken) == address(0));
require(bridgedTokenAddress(_nativeToken) == address(0));
```
However, there is no check that the `_nativeToken` is not bridged token, i.e.:
```solidity
require(nativeTokenAddress(_nativeToken) == address(0));
```
This can create a weird condition where the bridged token is again a native token. Once this occurs, the bridge fails to function correctly, as the bridged tokens are now handled as native tokens.
Similarly, administrators can also register an existing native token, as a non-native token. Consider the following example:
1. A native token T exists, which has already been bridged and where tokens of type T are locked up inside the mediator contract.
2. An administrator call `setCustomTokenAddressPair` with T as the `_bridgedToken` and some other fake token F as the supposedly native token on the other side.
3. The attacker transfers a lot of F token (which can be freely minted) over the bridge and thereby unlocks the T tokens.

This allows administrators to steal all native tokens held by the bridge.
However, the overall risk is rather low as only administrators can call `setCustomTokenAddressPair`.