### PR TITLE
Change memory storage location for data in callbacks

### DIFF
--- a/contracts/helpers/WETHOmnibridgeRouter.sol
+++ b/contracts/helpers/WETHOmnibridgeRouter.sol
@@ -3,6 +3,7 @@ pragma solidity 0.7.5;
 import "../interfaces/IOmnibridge.sol";
 import "../interfaces/IWETH.sol";
 import "../libraries/AddressHelper.sol";
+import "../libraries/Bytes.sol";
 import "../upgradeable_contracts/modules/OwnableModule.sol";
 import "../upgradeable_contracts/Claimable.sol";
 
@@ -62,7 +63,7 @@ contract WETHOmnibridgeRouter is OwnableModule, Claimable {
     function onTokenBridged(
         address _token,
         uint256 _value,
-        bytes calldata _data
+        bytes memory _data
     ) external {
         require(_token == address(WETH));
         require(msg.sender == address(bridge));
@@ -70,11 +71,7 @@ contract WETHOmnibridgeRouter is OwnableModule, Claimable {
 
         WETH.withdraw(_value);
 
-        address payable receiver;
-        assembly {
-            receiver := calldataload(120)
-        }
-        AddressHelper.safeSendValue(receiver, _value);
+        AddressHelper.safeSendValue(payable(Bytes.bytesToAddress(_data)), _value);
     }
 
     /**

--- a/contracts/upgradeable_contracts/components/common/TokensRelayer.sol
+++ b/contracts/upgradeable_contracts/components/common/TokensRelayer.sol
@@ -24,22 +24,18 @@ abstract contract TokensRelayer is BasicAMBMediator, ReentrancyGuard {
     function onTokenTransfer(
         address _from,
         uint256 _value,
-        bytes calldata _data
+        bytes memory _data
     ) external returns (bool) {
         if (!lock()) {
             bytes memory data = new bytes(0);
             address receiver = _from;
             if (_data.length >= 20) {
-                assembly {
-                    receiver := calldataload(120)
-                }
+                receiver = Bytes.bytesToAddress(_data);
                 if (_data.length > 20) {
                     assembly {
-                        data := mload(0x40)
-                        let size := sub(calldataload(100), 20)
+                        let size := sub(mload(_data), 20)
+                        data := add(_data, 20)
                         mstore(data, size)
-                        calldatacopy(add(data, 32), 152, size)
-                        mstore(0x40, add(add(data, 32), size))
                     }
                 }
             }


### PR DESCRIPTION
The function `onTokenTransfer` uses inline assembly to read the receiver and calldata from the calldata arguments. The assembly strongly relies on some assumptions about the [argument encoding of the Solidity](https://docs.soliditylang.org/en/v0.6.0/abi-spec.html). One of them is that there are no "garbage bits" between the byte offset of the `bytes calldata _data` variable and the length field of the `bytes calldata _data` argument. This assumption will hold true in most cases, but is not guaranteed to hold. This assumption can be eliminated letting the compiler copy the `_data` into the memory and dealing with it there. Full expectations about the expected information in the `_data` argument must be properly documented, to avoid the misinterpretation of the interface.
```solidity
function onTokenTransfer(
    address _from,
    uint256 _value,
    bytes calldata _data
) external returns (bool) {
```