### PR TITLE
Comment about TUSD in fixMediatorBalance

### DIFF
--- a/contracts/upgradeable_contracts/BasicOmnibridge.sol
+++ b/contracts/upgradeable_contracts/BasicOmnibridge.sol
@@ -229,8 +229,9 @@ abstract contract BasicOmnibridge is
      * @dev Allows to send to the other network the amount of locked tokens that can be forced into the contract
      * without the invocation of the required methods. (e. g. regular transfer without a call to onTokenTransfer)
      * @param _token address of the token contract.
-     * This method SHOULD not be called for tokens with double addresses
-     * (e.g. TUSD accessible at both 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E and 0x0000000000085d4780B73119b644AE5ecd22b376)
+     * Before calling this method, it must be carefully investigated how imbalance happened
+     * in order to avoid an attempt to steal the funds from a token with double addresses
+     * (e.g. TUSD is accessible at both 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E and 0x0000000000085d4780B73119b644AE5ecd22b376)
      * @param _receiver the address that will receive the tokens on the other network.
      */
     function fixMediatorBalance(address _token, address _receiver)

--- a/contracts/upgradeable_contracts/BasicOmnibridge.sol
+++ b/contracts/upgradeable_contracts/BasicOmnibridge.sol
@@ -229,6 +229,8 @@ abstract contract BasicOmnibridge is
      * @dev Allows to send to the other network the amount of locked tokens that can be forced into the contract
      * without the invocation of the required methods. (e. g. regular transfer without a call to onTokenTransfer)
      * @param _token address of the token contract.
+     * This method SHOULD not be called for tokens with double addresses
+     * (e.g. TUSD accessible at both 0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E and 0x0000000000085d4780B73119b644AE5ecd22b376)
      * @param _receiver the address that will receive the tokens on the other network.
      */
     function fixMediatorBalance(address _token, address _receiver)


### PR DESCRIPTION
Tokens that have more than one address, through which they can be called, can be stolen when
they are bridged. An example for such a token is TUSD. The attack would work as follows:
1. The token is already bridged using the first token address. An amount `X` has been transferred across the bridge.
2. An attacker bridges the token using another token address. The attacker also bridges `X` tokens. Now the mediator balance on the native side is `X` for both token addresses. However, the actual balance, when queried from `balanceOf` is `2*X` for both of them.
3. The attacker colludes with the administrators, which trigger a call to `fixMediatorBalance` on the native side and withdraw `X` amount of tokens.
4. Then, the attacker can withdraw `X` tokens, by sending back the bridged tokens.
Overall, turned `X` tokens into `2*X` tokens, when ignoring fees. The attacker managed to withdraw the full amount of bridged tokens.