### PR TITLE
Replace _fee argument in distributeFee by the balanceOf call

### DIFF
--- a/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManager.sol
+++ b/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManager.sol
@@ -187,13 +187,13 @@ contract OmnibridgeFeeManager is MediatorOwnableModule {
     /**
      * @dev Distributes the fee proportionally between registered reward addresses.
      * @param _token address of the token contract for which fee should be distributed.
-     * @param _fee fee amount to distribute.
      */
-    function distributeFee(address _token, uint256 _fee) external onlyMediator {
+    function distributeFee(address _token) external onlyMediator {
         uint256 numOfAccounts = rewardAddresses.length;
-        uint256 feePerAccount = _fee.div(numOfAccounts);
+        uint256 fee = IERC20(_token).balanceOf(address(this));
+        uint256 feePerAccount = fee.div(numOfAccounts);
         uint256 randomAccountIndex;
-        uint256 diff = _fee.sub(feePerAccount.mul(numOfAccounts));
+        uint256 diff = fee.sub(feePerAccount.mul(numOfAccounts));
         if (diff > 0) {
             randomAccountIndex = random(numOfAccounts);
         }

--- a/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManagerConnector.sol
+++ b/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManagerConnector.sol
@@ -77,7 +77,7 @@ abstract contract OmnibridgeFeeManagerConnector is Ownable {
                 } else {
                     IBurnableMintableERC677Token(_token).transfer(address(manager), fee);
                 }
-                manager.distributeFee(_token, fee);
+                manager.distributeFee(_token);
             }
             return fee;
         }


### PR DESCRIPTION
As part of the internal function `_distributeFee` of the `OmnibridgeFeeManagerConnector`
contract calls the token contract to transfer or mint the **fee** amount to the manager. In case the relevant token contract is native to Home side it might have transfer fees. Then, a value less than **fee** will be moved during the transfer to the `OmnibridgeFeeManager`. Later the `OmnibridgeFeeManager` tries to distribute this **fee** amount using `distributeFee` function. Because the actually transferred value will be smaller in case of Tokens with transfer fees, the `OmnibridgeFeeManager` will not have enough assets to perform the reward distribution with the required values.
Hence, the whole transaction will fail and such tokens cannot be moved across the bridge.

The proposed fix is the following:
* Use the result of `token.balanceOf(feeManager)` instead of the argument with calculated **fee** value.
* Do not revert if the token contract fails to transfer/mint tokens to the fee manager contract. It allows to make sure that the bridge operation execution will not fail due to a token which would like to avoid pay bridge fees.