### PR TITLE
Replace redundant if clause by comment in _getMinterFor

### DIFF
--- a/contracts/upgradeable_contracts/BasicOmnibridge.sol
+++ b/contracts/upgradeable_contracts/BasicOmnibridge.sol
@@ -387,7 +387,7 @@ abstract contract BasicOmnibridge is
      * @param _token address of the token to mint.
      * @return address of the minter contract that should be used for calling mint(address,uint256)
      */
-    function _getMinterFor(address _token) internal view virtual returns (IBurnableMintableERC677Token) {
+    function _getMinterFor(address _token) internal pure virtual returns (IBurnableMintableERC677Token) {
         return IBurnableMintableERC677Token(_token);
     }
 

--- a/contracts/upgradeable_contracts/HomeOmnibridge.sol
+++ b/contracts/upgradeable_contracts/HomeOmnibridge.sol
@@ -209,6 +209,10 @@ contract HomeOmnibridge is
         // It is possible to hardcode different token minter contracts here during compile time.
         // For example, the dedicated TokenMinter (0x857DD07866C1e19eb2CDFceF7aE655cE7f9E560d) is used for
         // bridged STAKE token (0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e).
+        if (_token == address(0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e)) {
+            // hardcoded address of the TokenMinter address
+            return IBurnableMintableERC677Token(0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e);
+        }
         return IBurnableMintableERC677Token(_token);
     }
 }

--- a/contracts/upgradeable_contracts/HomeOmnibridge.sol
+++ b/contracts/upgradeable_contracts/HomeOmnibridge.sol
@@ -206,10 +206,9 @@ contract HomeOmnibridge is
         override(BasicOmnibridge, OmnibridgeFeeManagerConnector)
         returns (IBurnableMintableERC677Token)
     {
-        if (_token == address(0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e)) {
-            // hardcoded address of the TokenMinter address
-            return IBurnableMintableERC677Token(0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e);
-        }
+        // It is possible to hardcode different token minter contracts here during compile time.
+        // For example, the dedicated TokenMinter (0x857DD07866C1e19eb2CDFceF7aE655cE7f9E560d) is used for
+        // bridged STAKE token (0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e).
         return IBurnableMintableERC677Token(_token);
     }
 }

--- a/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManagerConnector.sol
+++ b/contracts/upgradeable_contracts/modules/fee_manager/OmnibridgeFeeManagerConnector.sol
@@ -84,5 +84,5 @@ abstract contract OmnibridgeFeeManagerConnector is Ownable {
         return 0;
     }
 
-    function _getMinterFor(address _token) internal view virtual returns (IBurnableMintableERC677Token);
+    function _getMinterFor(address _token) internal pure virtual returns (IBurnableMintableERC677Token);
 }


### PR DESCRIPTION
This piece of code is used for hardcoding the `TokenMinter` address for STAKE token on the xDAI chain. Since it is not required in other scenarios, it is not necessary to keep such if-statement in the code.