### PR TITLE
Reduce gas cost of requestFailedMessageFix

### DIFF
--- a/contracts/upgradeable_contracts/components/common/FailedMessagesProcessor.sol
+++ b/contracts/upgradeable_contracts/components/common/FailedMessagesProcessor.sol
@@ -16,9 +16,10 @@ abstract contract FailedMessagesProcessor is BasicAMBMediator, BridgeOperationsS
      * @param _messageId id of the message which execution failed.
      */
     function requestFailedMessageFix(bytes32 _messageId) external {
-        require(!bridgeContract().messageCallStatus(_messageId));
-        require(bridgeContract().failedMessageReceiver(_messageId) == address(this));
-        require(bridgeContract().failedMessageSender(_messageId) == mediatorContractOnOtherSide());
+        IAMB bridge = bridgeContract();
+        require(!bridge.messageCallStatus(_messageId));
+        require(bridge.failedMessageReceiver(_messageId) == address(this));
+        require(bridge.failedMessageSender(_messageId) == mediatorContractOnOtherSide());
 
         bytes4 methodSelector = this.fixFailedMessage.selector;
         bytes memory data = abi.encodeWithSelector(methodSelector, _messageId);


### PR DESCRIPTION
The following code in `requestFailedMessageFix` is gas inefficient:
```solidity
require(!bridgeContract().messageCallStatus(_messageId));
require(bridgeContract().failedMessageReceiver(_messageId) == address(this));
require(bridgeContract().failedMessageSender(_messageId) == mediatorContractOnOtherSide());
```
As there is a storage load (SLOAD) inside the `bridgeContract()` function, this SLOAD will be executed three times in this case. Due to the about-to-be introduced EIP-2929 the additional costs of extra SLOADs from the same location are significantly lowered, but it could still be avoided to do it.